### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v4
               with:
-                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory
@@ -97,7 +96,6 @@ jobs:
             - uses: pnpm/action-setup@v4
               name: Install pnpm
               with:
-                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v4
               with:
-                  version: 8
+                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory
@@ -97,7 +97,7 @@ jobs:
             - uses: pnpm/action-setup@v4
               name: Install pnpm
               with:
-                  version: 8
+                  version: 9
                   run_install: false
 
             - name: Get pnpm store directory

--- a/app/frontend/components/App/Home/MyEditor/MyToolbarPlugin.tsx
+++ b/app/frontend/components/App/Home/MyEditor/MyToolbarPlugin.tsx
@@ -62,6 +62,22 @@ function FloatingLinkEditor({ editor }: { editor: LexicalEditor }) {
 	const inputRef = useRef(null)
 	const mouseDownRef = useRef(false)
 	const [linkUrl, setLinkUrl] = useState('')
+
+	function sanitizeUrl(url: string): string {
+		try {
+			const parsedUrl = new URL(url, window.location.origin)
+			if (
+				parsedUrl.protocol === 'http:' ||
+				parsedUrl.protocol === 'https:' ||
+				parsedUrl.protocol === 'mailto:'
+			) {
+				return parsedUrl.href
+			}
+		} catch {
+			// Invalid URL
+		}
+		return ''
+	}
 	const [isEditMode, setEditMode] = useState(false)
 	const [lastSelection, setLastSelection] = useState<BaseSelection>()
 
@@ -158,7 +174,7 @@ function FloatingLinkEditor({ editor }: { editor: LexicalEditor }) {
 					className='link-input'
 					value={linkUrl}
 					onChange={(event) => {
-						setLinkUrl(event.target.value)
+						setLinkUrl(sanitizeUrl(event.target.value))
 					}}
 					onKeyDown={(event) => {
 						if (event.key === 'Enter') {


### PR DESCRIPTION
Potential fix for [https://github.com/knownasnaffy/inner-ink/security/code-scanning/1](https://github.com/knownasnaffy/inner-ink/security/code-scanning/1)

To fix the issue, we need to sanitize the `linkUrl` value before using it in the `href` attribute of the `<a>` tag. This can be achieved by validating the URL to ensure it is safe and conforms to expected formats. A library like `DOMPurify` can be used to sanitize the input, or a custom validation function can be implemented to allow only safe URLs (e.g., those starting with `http://`, `https://`, or `mailto:`).

The fix involves:
1. Adding a utility function to validate or sanitize the `linkUrl`.
2. Updating the `onChange` handler (line 161) to sanitize the input before setting it to `linkUrl`.
3. Ensuring that only sanitized values are used in the `href` attribute (line 185).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
